### PR TITLE
Adding re-handshaking functionality

### DIFF
--- a/test/fixtures/childOrigin.html
+++ b/test/fixtures/childOrigin.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Iframe</title>
+  </head>
+  <body>
+    Test Iframe
+
+    <script>
+      window.onerror = function () { console.log.apply(console, arguments); };
+    </script>
+    <script src="rsvp.min.js"></script>
+    <script type="text/javascript" src="penpal.js"></script>
+    <script type="text/javascript">
+      Penpal.Promise = RSVP.Promise;
+      Penpal.debug = true;
+
+      var parentAPI;
+      var parentReturnValue;
+
+      var methods = {
+        multiply: function(num1, num2) {
+          return num1 * num2;
+        },
+        multiplyAsync: function(num1, num2) {
+          return new RSVP.Promise(function(resolve) {
+            resolve(num1 * num2);
+          });
+        },
+        addUsingParent: function() {
+          parentAPI.add(3, 6).then(function(value) {
+            parentReturnValue = value;
+          });
+        },
+        getParentReturnValue: function() {
+          return parentReturnValue;
+        },
+        getRejectedPromise: function() {
+          return RSVP.Promise.reject('test error message');
+        },
+        throwError: function() {
+          throw new Error('Oh nos!');
+        }
+      };
+
+      Penpal.connectToParent({
+        parentOrigin: 'http://localhost:9001',
+        methods: methods
+      }).promise.then(function(parent) {
+        parentAPI = parent;
+      });
+    </script>
+  </body>
+</html>

--- a/test/fixtures/childOriginArray.html
+++ b/test/fixtures/childOriginArray.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Test Iframe</title>
+  </head>
+  <body>
+    Test Iframe
+
+    <script>
+      window.onerror = function () { console.log.apply(console, arguments); };
+    </script>
+    <script src="rsvp.min.js"></script>
+    <script type="text/javascript" src="penpal.js"></script>
+    <script type="text/javascript">
+      Penpal.Promise = RSVP.Promise;
+      Penpal.debug = true;
+
+      var parentAPI;
+      var parentReturnValue;
+
+      var methods = {
+        multiply: function(num1, num2) {
+          return num1 * num2;
+        },
+        multiplyAsync: function(num1, num2) {
+          return new RSVP.Promise(function(resolve) {
+            resolve(num1 * num2);
+          });
+        },
+        addUsingParent: function() {
+          parentAPI.add(3, 6).then(function(value) {
+            parentReturnValue = value;
+          });
+        },
+        getParentReturnValue: function() {
+          return parentReturnValue;
+        },
+        getRejectedPromise: function() {
+          return RSVP.Promise.reject('test error message');
+        },
+        throwError: function() {
+          throw new Error('Oh nos!');
+        }
+      };
+
+      Penpal.connectToParent({
+        parentOrigin: ['http://localhost:9001'],
+        methods: methods
+      }).promise.then(function(parent) {
+        parentAPI = parent;
+      });
+    </script>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ describe('Penpal', () => {
   beforeAll(() => {
     Penpal.Promise = RSVP.Promise;
     Penpal.debug = true;
+    jasmine.getEnv().defaultTimeoutInterval=10000;
   });
 
   it('should complete a handshake', (done) => {
@@ -44,6 +45,34 @@ describe('Penpal', () => {
   it('should call a function on the child', (done) => {
     const connection = Penpal.connectToChild({
       url: `http://${HOST}:9000/child.html`
+    });
+
+    connection.promise.then((child) => {
+      child.multiply(2, 5).then((value) => {
+        expect(value).toEqual(10);
+        connection.destroy();
+        done();
+      });
+    });
+  });
+  
+  it('should call a function on the child with origin set', (done) => {
+    const connection = Penpal.connectToChild({
+      url: `http://${HOST}:9000/childOrigin.html`
+    });
+
+    connection.promise.then((child) => {
+      child.multiply(2, 5).then((value) => {
+        expect(value).toEqual(10);
+        connection.destroy();
+        done();
+      });
+    });
+  });
+
+  it('should call a function on the child with origin array set', (done) => {
+    const connection = Penpal.connectToChild({
+      url: `http://${HOST}:9000/childOriginArray.html`
     });
 
     connection.promise.then((child) => {

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,6 @@ describe('Penpal', () => {
   beforeAll(() => {
     Penpal.Promise = RSVP.Promise;
     Penpal.debug = true;
-    jasmine.getEnv().defaultTimeoutInterval=10000;
   });
 
   it('should complete a handshake', (done) => {


### PR DESCRIPTION
This modifies the Parent's message listener to listen for 'HANDSHAKE' messages.
When it receives one, it attempts to execute the steps of a HANDSHAKE again.
This allows for Penpal to be used in cases where where iframe.load is called
before penpal is loaded, such as with asynchronous loading (System.js)

As we thought about this, we realized that maybe we should not be waiting on iframe load, but rather module load, to trigger the handshake from the parent. This doesn't get there yet, but this starts to illustrate where that idea would end up. This also doesn't involve changing the function interfaces, so it's a non-intrusive start.