### PR TITLE
Allow iframe sandbox options to be configured in connectToChild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 lib
 dist
+package-lock.json
+.idea

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,7 @@ declare namespace Penpal {
     interface IChildConnectionOptions extends IConnectionOptions {
         appendTo?: HTMLElement;
         url: string;
+        sandboxOptions: Array<string>;
     }
 
     interface IParentConnectionOptions extends IConnectionOptions {

--- a/src/index.js
+++ b/src/index.js
@@ -255,12 +255,16 @@ const connectCallReceiver = (info, methods, destructionPromise) => {
  * @param {Object} [options.methods] Methods that may be called by the iframe.
  * @return {Child}
  */
-Penpal.connectToChild = ({ url, appendTo, methods = {} }) => {
+Penpal.connectToChild = ({ url, appendTo, methods = {}, sandboxOptions = [] }) => {
   let destroy;
   const destructionPromise = new DestructionPromise(resolve => destroy = resolve);
 
   const parent = window;
   const iframe = document.createElement('iframe');
+
+  sandboxOptions.forEach((sandboxOption) => {
+    iframe.sandbox.add(sandboxOption);
+  });
 
   (appendTo || document.body).appendChild(iframe);
 

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,18 @@ describe('Penpal', () => {
     expect(connection.iframe.parentNode).toBe(document.body);
   });
 
+  it('should create an iframe and allow sandbox properties to be configured', () => {
+    const connection = Penpal.connectToChild({
+      url: `http://${HOST}:9000/child.html`,
+      sandboxOptions: ['allow-scripts', 'allow-presentation']
+    });
+
+    expect(connection.iframe).toBeDefined();
+    expect(connection.iframe.src).toBe(`http://${HOST}:9000/child.html`);
+    expect(connection.iframe.parentNode).toBe(document.body);
+    expect(connection.iframe.sandbox.toString()).toEqual('allow-scripts allow-presentation');
+  })
+
   it('should create an iframe and add it to a specific element', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -54,7 +66,7 @@ describe('Penpal', () => {
       });
     });
   });
-  
+
   it('should call a function on the child with origin set', (done) => {
     const connection = Penpal.connectToChild({
       url: `http://${HOST}:9000/childOrigin.html`

--- a/test/index.js
+++ b/test/index.js
@@ -33,11 +33,8 @@ describe('Penpal', () => {
       sandboxOptions: ['allow-scripts', 'allow-presentation']
     });
 
-    expect(connection.iframe).toBeDefined();
-    expect(connection.iframe.src).toBe(`http://${HOST}:9000/child.html`);
-    expect(connection.iframe.parentNode).toBe(document.body);
     expect(connection.iframe.sandbox.toString()).toEqual('allow-scripts allow-presentation');
-  })
+  });
 
   it('should create an iframe and add it to a specific element', () => {
     const container = document.createElement('div');


### PR DESCRIPTION
Iframes support a [sandbox attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) which is widely supported by modern browsers and can provided an added layer of security.

This patch simply allows passing in a list of sandbox attributes, and assumes they will be applied to the internally constructed sandbox frame.