### PR TITLE
Changed type of iframe to HTMLIFrameElement.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare namespace Penpal {
   }
 
   interface IChildConnectionObject extends IConnectionObject {
-    iframe: HTMLElement;
+    iframe: HTMLIFrameElement;
   }
 
   type ConnectionMethods<T> = {


### PR DESCRIPTION
Using a more specific type for `IChildConnectionObject.iframe` makes
working in TypeScript more pleasant; the compiler will no longer
complain about using properties specific to iframe elements (like `src`
or `name`) on that object.