### PR TITLE
Fixed edge case issue in connectToChild handleMessage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -324,7 +324,6 @@ Penpal.connectToChild = ({ url, appendTo, methods = {}, timeout }) => {
     }
   });
 
-  const child = iframe.contentWindow || iframe.contentDocument.parentWindow;
   const childOrigin = getOriginFromUrl(url);
   const promise = new Penpal.Promise((resolveConnectionPromise, reject) => {
     let connectionTimeoutId;
@@ -347,6 +346,8 @@ Penpal.connectToChild = ({ url, appendTo, methods = {}, timeout }) => {
     let destroyCallReceiver;
 
     const handleMessage = (event) => {
+      const child = iframe.contentWindow || iframe.contentDocument.parentWindow;
+      
       if (event.source === child &&
           event.origin === childOrigin &&
           event.data.penpal === HANDSHAKE) {


### PR DESCRIPTION
I don't fully understand what is happening in my edge case, but this seems to solve the problem.

I used Penpal on a few sites and it worked fine, but on another site it wasn't responding to the handshake. There are too many differences between the projects to know the exact cause of the issue, but here were my observations:

(All tested in chrome)
Originally, `iframe.contentWindow` would return a `Window` object. Later, it returns a `global` object. I'm not entirely sure why, my guess would be related to webpack.

On the sites that Penpal worked fine, logging `child` in `handleMessage` would return the updated `global` object, and the `event.source` would also return it, so everything was fine.

On the site Penpal didn't work, logging `child` in `handleMessage` would return the original `Window` object, but the `event.source` was returning the `global` object, so the `event.source === child` condition would fail. But, logging `iframe.contentWindow` in `handleMessage` did return the `global` object, so it allowed the conditional to pass.

So to solve my issue, I moved the child definition inside the handleMessage event so that in both cases it is getting the correct source object for the child. I'm not sure if there are any implications to this change that I'm not seeing, but everything seems to be going well so far.