### PR TITLE
Allow generic types for `IConnectionObject`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,11 @@
 declare namespace Penpal {
 
-  interface IConnectionObject {
-    promise: Promise<any>;
+  interface IConnectionObject<Methods extends ConnectionMethods> {
+    promise: Promise<Methods>;
     destroy: () => {};
   }
 
-  interface IChildConnectionObject extends IConnectionObject {
+  interface IChildConnectionObject<Methods extends ConnectionMethods> extends IConnectionObject<Methods> {
     iframe: HTMLIFrameElement;
   }
 
@@ -32,8 +32,8 @@ declare namespace Penpal {
   }
 
   interface PenpalStatic {
-    connectToChild(options: IChildConnectionOptions): IChildConnectionObject;
-    connectToParent(options?: IParentConnectionOptions): IConnectionObject;
+    connectToChild<Methods extends ConnectionMethods = any>(options: IChildConnectionOptions): IChildConnectionObject<Methods>;
+    connectToParent<Methods extends ConnectionMethods = any>(options?: IParentConnectionOptions): IConnectionObject<Methods>;
     Promise: typeof Promise;
     debug: boolean;
     ERR_CONNECTION_DESTROYED: ERR_CONNECTION_DESTROYED;


### PR DESCRIPTION
With generic types we can now have a strongly typed `IConnectionObject` promise. We can optionally define the types whilst calling `connectToChild` or `connectToParent`.

```ts
interface ParentMethods {
  multiply: (num1: number, num2: number) => number;
  divide: (num1: number, num2: number) => Promise<number>;
}

const parent = await Penpal.connectToParent<ParentMethods>(options).promise;

const a = await parent.multiply(2, 6);
const b = await parent.divide(12, 4);
const c = await parent.add(3, 1); // [ts] Property 'add' does not exist on type 'ParentMethods'
```

If no type is provided it will default to `any` which is the current value so nothing will break.