### PR TITLE
remove parent window message handler if child iframe no longer in DOM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -389,6 +389,13 @@ Penpal.connectToChild = ({ url, appendTo, iframe, methods = {}, timeout }) => {
     let destroyCallReceiver;
 
     const handleMessage = event => {
+      //if the DOM no longer contains the iframe
+      //remove the listner from the parentWindow
+      //this ensures handleMessage isn't being called on non-existent iframes
+      if( !iframe || !document.contains(iframe) ){
+        return parent.removeEventListener(handleMessage);
+      }
+
       const child = iframe.contentWindow || iframe.contentDocument.parentWindow;
       if (
         event.source === child &&


### PR DESCRIPTION
This would what I experienced in #27 which was old messageHandler calls trying to connect to an iframe that no longer exists. 