### PR TITLE
Allow child to get the parent origin

### DIFF
--- a/src/connectToParent.js
+++ b/src/connectToParent.js
@@ -42,6 +42,11 @@ export default ({ parentOrigin = '*', methods = {}, timeout, debug } = {}) => {
   const child = window;
   const parent = child.parent;
 
+  let parentOriginResolve;
+  const parentOriginPromise = new Promise(
+    resolve => (parentOriginResolve = resolve)
+  );
+
   const promise = new Promise((resolveConnectionPromise, reject) => {
     let connectionTimeoutId;
 
@@ -113,6 +118,7 @@ export default ({ parentOrigin = '*', methods = {}, timeout, debug } = {}) => {
 
       clearTimeout(connectionTimeoutId);
       resolveConnectionPromise(callSender);
+      parentOriginResolve(event.origin);
     };
 
     child.addEventListener(MESSAGE, handleMessageEvent);
@@ -138,6 +144,7 @@ export default ({ parentOrigin = '*', methods = {}, timeout, debug } = {}) => {
 
   return {
     promise,
+    parentOriginPromise,
     destroy
   };
 };


### PR DESCRIPTION
Hi 👋 
This is the first time I contribute to this project, I hope you will find it useful 😊

In some cases, where the parent domain is unknown (e.g penpal is used inside an SDK), it can be useful for the child to know the parent origin.

This pull request implements this feature by adding a new promise (`parentOriginPromise`) to the response of the `connectToParent` method.

Code example:
```javascript
const penpal = Penpal.connectToParent({methods: {...}})
penpal.parentOriginPromise.then(parentOrigin => console.log(parentOrigin))
```