### PR TITLE
Restore support for IE11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -476,7 +476,7 @@ Penpal.connectToChild = ({ url, appendTo, iframe, methods = {}, timeout }) => {
     // to the iframe in their closures, the iframe would stick around
     // too.
     var checkIframeInDocIntervalId = setInterval(() => {
-      if (!document.contains(iframe)) {
+      if (!document.body.contains(iframe)) {
         clearInterval(checkIframeInDocIntervalId);
         destroy();
       }


### PR DESCRIPTION
as promised for branch 3.x


I noticed in my Sentry that this happens for a fraction of users that have something using Penpal loaded.

I'm aware Penpal dropped support for IE but 3.12 has this bug: document.contains is not defined in IE11
