### PR TITLE
Fix problems with document parsing sinchronicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ import connectToChild from 'penpal/lib/connectToChild';
 
 const iframe = document.createElement('iframe');
 iframe.src = 'http://example.com/iframe.html';
-document.body.appendChild(iframe);
+if (document.readyState === "complete"
+  || document.readyState === "loaded"
+  || document.readyState === "interactive") {
+  document.body.appendChild(iframe);
+} else {
+  document.addEventListener("DOMContentLoaded", () => {
+    document.body.appendChild(iframe);
+  }); 
+}  
 
 const connection = connectToChild({
   // The iframe to which a connection should be made

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ import connectToChild from 'penpal/lib/connectToChild';
 const iframe = document.createElement('iframe');
 iframe.src = 'http://example.com/iframe.html';
 if (document.readyState === "complete"
-  || document.readyState === "loaded"
   || document.readyState === "interactive") {
   document.body.appendChild(iframe);
 } else {


### PR DESCRIPTION
Currently the code present in the readme will cause an exception if executed before the document has been parsed, this PR fixes that by preventing that from happening.

## How to reproduce the error
Place the readme's code in a script tag inside the `<head>` element of an html page. More concretely, what I'm doing is building the readme's code along with the penpal library into a single js file using webpack and then importing that script into a page in the following way:
```html
<html>
  <head>
    <script src="readme-code-bundle.js"></script>
  </head>
  <body></body>
</html>
```

## How this PR fixes the problem
It makes the code check if the document has already been parsed and, in case that it hasn't, it sets up an event that will be triggered when the document is ready.