### PR TITLE
Adding generic arguments and making build work cross platform. Fixes #47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2697,6 +2697,12 @@
       "dev": true,
       "optional": true
     },
+    "filesize": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
+      "dev": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2764,6 +2770,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -4335,6 +4352,15 @@
             "picomatch": "^2.0.7"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5432,9 +5458,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -5554,6 +5580,17 @@
         "https-proxy-agent": "^3.0.0",
         "lodash": "^4.16.6",
         "rimraf": "^2.5.4"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "saucelabs": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "clean": "rm -rf lib dist",
+    "clean": "rimraf lib/** dist/**",
     "build:lib": "tsc --outDir lib",
     "build:dist": "rollup --config rollup.config.js && terser dist/penpal.js -o dist/penpal.min.js -m --source-map",
-    "build": "npm-run-all clean build:lib build:dist && ls -lh dist/penpal.min.js",
+    "build:analysis": "node ./scripts/filesize dist/penpal.min.js",
+    "build": "npm-run-all clean build:lib build:dist build:analysis",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{json,js,md,html,babelrc,eslintrc}\"",
     "test": "npm-run-all clean runTests",
@@ -74,6 +75,8 @@
     "serve-static": "^1.13.2",
     "terser": "^4.6.11",
     "typescript": "^3.8.3",
-    "yargs": "^15.3.1"
+    "yargs": "^15.3.1",
+    "rimraf": "^3.0.2",
+    "filesize": "^6.1.0"
   }
 }

--- a/scripts/filesize.js
+++ b/scripts/filesize.js
@@ -1,0 +1,12 @@
+const filesize = require('filesize');
+const fs = require('fs');
+
+const fileName = process.argv[2];
+
+const stats = fs.statSync(fileName);
+
+const size = stats.size;
+
+const human = filesize(size);
+
+console.log(`File size of '${fileName}' is: ${human}`);

--- a/src/child/connectToParent.ts
+++ b/src/child/connectToParent.ts
@@ -35,7 +35,7 @@ type Options = {
   debug?: boolean;
 };
 
-type Connection<TCallSender extends CallSender = CallSender> = {
+type Connection<TCallSender extends object = CallSender> = {
   /**
    * A promise which will be resolved once a connection has been established.
    */
@@ -50,7 +50,7 @@ type Connection<TCallSender extends CallSender = CallSender> = {
 /**
  * Attempts to establish communication with the parent window.
  */
-export default <TCallSender extends CallSender = CallSender>(options: Options = {}): Connection<TCallSender> => {
+export default <TCallSender extends object = CallSender>(options: Options = {}): Connection<TCallSender> => {
   const { parentOrigin = '*', methods = {}, timeout, debug = false } = options;
   const log = createLogger(debug);
   const destructor = createDestructor();

--- a/src/child/connectToParent.ts
+++ b/src/child/connectToParent.ts
@@ -35,11 +35,11 @@ type Options = {
   debug?: boolean;
 };
 
-type Connection = {
+type Connection<TCallSender extends CallSender = CallSender> = {
   /**
    * A promise which will be resolved once a connection has been established.
    */
-  promise: Promise<CallSender>;
+  promise: Promise<TCallSender>;
   /**
    * A method that, when called, will disconnect any messaging channels.
    * You may call this even before a connection has been established.
@@ -50,7 +50,7 @@ type Connection = {
 /**
  * Attempts to establish communication with the parent window.
  */
-export default (options: Options = {}): Connection => {
+export default <TCallSender extends CallSender = CallSender>(options: Options = {}): Connection<TCallSender> => {
   const { parentOrigin = '*', methods = {}, timeout, debug = false } = options;
   const log = createLogger(debug);
   const destructor = createDestructor();
@@ -73,7 +73,7 @@ export default (options: Options = {}): Connection => {
     window.parent.postMessage(synMessage, parentOriginForSyn);
   };
 
-  const promise: Promise<CallSender> = new Promise((resolve, reject) => {
+  const promise: Promise<TCallSender> = new Promise((resolve, reject) => {
     const stopConnectionTimeout = startConnectionTimeout(timeout, destroy);
     const handleMessage = (event: MessageEvent) => {
       // Under niche scenarios, we get into this function after
@@ -92,7 +92,7 @@ export default (options: Options = {}): Connection => {
       }
 
       if (event.data.penpal === MessageType.SynAck) {
-        const callSender = handleSynAckMessage(event);
+        const callSender = handleSynAckMessage(event) as TCallSender;
         if (callSender) {
           window.removeEventListener(NativeEventType.Message, handleMessage);
           stopConnectionTimeout();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,3 @@
-// import _connectToChild from './parent/connectToChild';
-// import _connectToParent from './child/connectToParent';
-// import { ErrorCode as _ErrorCode } from './enums';
-
-//export const connectToChild = _connectToChild;
-//export const connectToParent = _connectToParent;
-//export const ErrorCode = _ErrorCode;
-
 export { default as connectToChild } from './parent/connectToChild';
 export { default as connectToParent } from './child/connectToParent';
 export { ErrorCode } from './enums';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ import { ErrorCode as _ErrorCode } from './enums';
 export const connectToChild = _connectToChild;
 export const connectToParent = _connectToParent;
 export const ErrorCode = _ErrorCode;
+export { CallSender } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
-import _connectToChild from './parent/connectToChild';
-import _connectToParent from './child/connectToParent';
-import { ErrorCode as _ErrorCode } from './enums';
+// import _connectToChild from './parent/connectToChild';
+// import _connectToParent from './child/connectToParent';
+// import { ErrorCode as _ErrorCode } from './enums';
 
-export const connectToChild = _connectToChild;
-export const connectToParent = _connectToParent;
-export const ErrorCode = _ErrorCode;
-export { CallSender } from './types'
+//export const connectToChild = _connectToChild;
+//export const connectToParent = _connectToParent;
+//export const ErrorCode = _ErrorCode;
+
+export { default as connectToChild } from './parent/connectToChild';
+export { default as connectToParent } from './child/connectToParent';
+export { ErrorCode } from './enums';

--- a/src/parent/connectToChild.ts
+++ b/src/parent/connectToChild.ts
@@ -35,11 +35,11 @@ type Options = {
   debug?: boolean;
 };
 
-type Connection = {
+type Connection<TCallSender extends CallSender = CallSender> = {
   /**
    * A promise which will be resolved once a connection has been established.
    */
-  promise: Promise<CallSender>;
+  promise: Promise<TCallSender>;
   /**
    * A method that, when called, will disconnect any messaging channels.
    * You may call this even before a connection has been established.
@@ -50,7 +50,7 @@ type Connection = {
 /**
  * Attempts to establish communication with an iframe.
  */
-export default (options: Options): Connection => {
+export default <TCallSender extends CallSender = CallSender>(options: Options): Connection<TCallSender> => {
   let { iframe, methods = {}, childOrigin, timeout, debug = false } = options;
 
   const log = createLogger(debug);
@@ -80,7 +80,7 @@ export default (options: Options): Connection => {
     log
   );
 
-  const promise: Promise<CallSender> = new Promise((resolve, reject) => {
+  const promise: Promise<TCallSender> = new Promise((resolve, reject) => {
     const stopConnectionTimeout = startConnectionTimeout(timeout, destroy);
     const handleMessage = (event: MessageEvent) => {
       if (event.source !== iframe.contentWindow || !event.data) {
@@ -93,7 +93,7 @@ export default (options: Options): Connection => {
       }
 
       if (event.data.penpal === MessageType.Ack) {
-        const callSender = handleAckMessage(event);
+        const callSender = handleAckMessage(event) as TCallSender;
 
         if (callSender) {
           stopConnectionTimeout();

--- a/src/parent/connectToChild.ts
+++ b/src/parent/connectToChild.ts
@@ -35,7 +35,7 @@ type Options = {
   debug?: boolean;
 };
 
-type Connection<TCallSender extends CallSender = CallSender> = {
+type Connection<TCallSender extends object = CallSender> = {
   /**
    * A promise which will be resolved once a connection has been established.
    */
@@ -50,7 +50,7 @@ type Connection<TCallSender extends CallSender = CallSender> = {
 /**
  * Attempts to establish communication with an iframe.
  */
-export default <TCallSender extends CallSender = CallSender>(options: Options): Connection<TCallSender> => {
+export default <TCallSender extends object = CallSender>(options: Options): Connection<TCallSender> => {
   let { iframe, methods = {}, childOrigin, timeout, debug = false } = options;
 
   const log = createLogger(debug);


### PR DESCRIPTION
Hello,

Turns out CallSender is used in a variety of places in the codebase and I didn't feel comfortable changing them all to be generic, plus it introduced issues where CallSender was instantiated. 

So instead I have added the small restriction that the generic type parameter must extend from CallSender. To facilitate this I have re-exported that type from the main entry point. It doesn't affect the resulting js code in any way.

As the returned type should be just an interface shim to make sure the correct methods and types are being passed through, I don't foresee an issue with this but am open to suggestions.

I develop on windows so I've made the build process work cross platform as well (in theory).

Fixes #47 
