### PR TITLE
Fixes typescript generics to be correct for the returned proxy object

### DIFF
--- a/src/child/connectToParent.ts
+++ b/src/child/connectToParent.ts
@@ -1,6 +1,6 @@
 import createDestructor from '../createDestructor';
 import createLogger from '../createLogger';
-import { SynMessage, Methods, PenpalError, CallSender } from '../types';
+import { SynMessage, Methods, PenpalError, CallSender, AsyncMethodReturns } from '../types';
 import { ErrorCode, MessageType, NativeEventType } from '../enums';
 import validateWindowIsIframe from './validateWindowIsIframe';
 import handleSynAckMessageFactory from './handleSynAckMessageFactory';
@@ -39,7 +39,7 @@ type Connection<TCallSender extends object = CallSender> = {
   /**
    * A promise which will be resolved once a connection has been established.
    */
-  promise: Promise<TCallSender>;
+  promise: Promise<AsyncMethodReturns<TCallSender>>;
   /**
    * A method that, when called, will disconnect any messaging channels.
    * You may call this even before a connection has been established.
@@ -73,7 +73,7 @@ export default <TCallSender extends object = CallSender>(options: Options = {}):
     window.parent.postMessage(synMessage, parentOriginForSyn);
   };
 
-  const promise: Promise<TCallSender> = new Promise((resolve, reject) => {
+  const promise: Promise<AsyncMethodReturns<TCallSender>> = new Promise((resolve, reject) => {
     const stopConnectionTimeout = startConnectionTimeout(timeout, destroy);
     const handleMessage = (event: MessageEvent) => {
       // Under niche scenarios, we get into this function after
@@ -92,7 +92,7 @@ export default <TCallSender extends object = CallSender>(options: Options = {}):
       }
 
       if (event.data.penpal === MessageType.SynAck) {
-        const callSender = handleSynAckMessage(event) as TCallSender;
+        const callSender = handleSynAckMessage(event) as AsyncMethodReturns<TCallSender>;
         if (callSender) {
           window.removeEventListener(NativeEventType.Message, handleMessage);
           stopConnectionTimeout();

--- a/src/parent/connectToChild.ts
+++ b/src/parent/connectToChild.ts
@@ -3,7 +3,7 @@ import getOriginFromSrc from './getOriginFromSrc';
 import createLogger from '../createLogger';
 import handleSynMessageFactory from './handleSynMessageFactory';
 import handleAckMessageFactory from './handleAckMessageFactory';
-import { CallSender, Methods, PenpalError } from '../types';
+import { CallSender, Methods, PenpalError, AsyncMethodReturns } from '../types';
 import { ErrorCode, MessageType, NativeEventType } from '../enums';
 import validateIframeHasSrcOrSrcDoc from './validateIframeHasSrcOrSrcDoc';
 import monitorIframeRemoval from './monitorIframeRemoval';
@@ -39,7 +39,7 @@ type Connection<TCallSender extends object = CallSender> = {
   /**
    * A promise which will be resolved once a connection has been established.
    */
-  promise: Promise<TCallSender>;
+  promise: Promise<AsyncMethodReturns<TCallSender>>;
   /**
    * A method that, when called, will disconnect any messaging channels.
    * You may call this even before a connection has been established.
@@ -80,7 +80,7 @@ export default <TCallSender extends object = CallSender>(options: Options): Conn
     log
   );
 
-  const promise: Promise<TCallSender> = new Promise((resolve, reject) => {
+  const promise: Promise<AsyncMethodReturns<TCallSender>> = new Promise((resolve, reject) => {
     const stopConnectionTimeout = startConnectionTimeout(timeout, destroy);
     const handleMessage = (event: MessageEvent) => {
       if (event.source !== iframe.contentWindow || !event.data) {
@@ -93,7 +93,7 @@ export default <TCallSender extends object = CallSender>(options: Options): Conn
       }
 
       if (event.data.penpal === MessageType.Ack) {
-        const callSender = handleAckMessage(event) as TCallSender;
+        const callSender = handleAckMessage(event) as AsyncMethodReturns<TCallSender>;
 
         if (callSender) {
           stopConnectionTimeout();

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,3 +89,19 @@ export type CallSender = {
  * A Penpal-specific error.
  */
 export type PenpalError = Error & { code: ErrorCode };
+
+/**
+ * A mapped type to extract only object properties which are functions.
+ */
+export type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
+
+/**
+ * A mapped type to convert non async methods into async methods and exclude any non function properties.
+ */
+export type AsyncMethodReturns<T, K extends keyof T = FunctionPropertyNames<T>> = {
+  [KK in K]: T[KK] extends (...args: any[]) => PromiseLike<any>
+    ? T[KK]
+    : T[KK] extends (...args: infer A) => infer R
+    ? (...args: A) => Promise<R>
+    : T[KK]
+};


### PR DESCRIPTION
Apologies for creating extra work for you but I screwed up in the previous pull request.

I neglected the fact that the returned promise is an proxy object which all methods return a promise object. 

This fixes the typescript typings so the generic argument is automatically mapped to a type which the following:
1. Only has function properties
1. All functions return a promise, with the correct inferred type.

