### PR TITLE
Add option to configure iframe removal monitoring interval

### DIFF
--- a/src/parent/connectToChild.ts
+++ b/src/parent/connectToChild.ts
@@ -15,6 +15,16 @@ type Options = {
    */
   iframe: HTMLIFrameElement;
   /**
+   * The interval that defines how often Penpal checks for iframe removal.
+   * This feature is enabled by default and prevents memory leaks when
+   * the iframe is removed from its parent but the consumer hasn't
+   * called `destroy()`.
+   *
+   * The default value is `60000` ms. A value of `0` disables iframe
+   * removal monitoring.
+   */
+  iframeRemovalMonitoringInterval?: number;
+  /**
    * Methods that may be called by the iframe.
    */
   methods?: Methods;
@@ -51,7 +61,7 @@ type Connection<TCallSender extends object = CallSender> = {
  * Attempts to establish communication with an iframe.
  */
 export default <TCallSender extends object = CallSender>(options: Options): Connection<TCallSender> => {
-  let { iframe, methods = {}, childOrigin, timeout, debug = false } = options;
+  let { iframe, iframeRemovalMonitoringInterval = undefined, methods = {}, childOrigin, timeout, debug = false } = options;
 
   const log = createLogger(debug);
   const destructor = createDestructor();
@@ -106,7 +116,7 @@ export default <TCallSender extends object = CallSender>(options: Options): Conn
     window.addEventListener(NativeEventType.Message, handleMessage);
 
     log('Parent: Awaiting handshake');
-    monitorIframeRemoval(iframe, destructor);
+    monitorIframeRemoval(iframe, destructor, iframeRemovalMonitoringInterval);
 
     onDestroy((error?: PenpalError) => {
       window.removeEventListener(NativeEventType.Message, handleMessage);

--- a/src/parent/monitorIframeRemoval.ts
+++ b/src/parent/monitorIframeRemoval.ts
@@ -1,6 +1,6 @@
 import { Destructor } from '../createDestructor';
 
-const CHECK_IFRAME_IN_DOC_INTERVAL = 60000;
+const DEFAULT_CHECK_IFRAME_IN_DOC_INTERVAL = 60000;
 
 /**
  * Monitors for iframe removal and destroys connection if iframe
@@ -11,14 +11,18 @@ const CHECK_IFRAME_IN_DOC_INTERVAL = 60000;
  * reference to the iframe in their closures, the iframe would stick
  * around too.
  */
-export default (iframe: HTMLIFrameElement, destructor: Destructor) => {
+export default (iframe: HTMLIFrameElement, destructor: Destructor, interval: number | undefined) => {
+  if (interval === 0) {
+    return;
+  }
+
   const { destroy, onDestroy } = destructor;
   const checkIframeInDocIntervalId = setInterval(() => {
     if (!document.contains(iframe)) {
       clearInterval(checkIframeInDocIntervalId);
       destroy();
     }
-  }, CHECK_IFRAME_IN_DOC_INTERVAL);
+  }, interval === undefined ? DEFAULT_CHECK_IFRAME_IN_DOC_INTERVAL : interval);
 
   onDestroy(() => {
     clearInterval(checkIframeInDocIntervalId);


### PR DESCRIPTION
Besides, this patch allows disabling iframe removal monitoring by passing a value of `0`.