### PR TITLE
fix Object.keys issue

### DIFF
--- a/src/child/handleSynAckMessageFactory.ts
+++ b/src/child/handleSynAckMessageFactory.ts
@@ -9,6 +9,10 @@ import connectCallReceiver from '../connectCallReceiver';
 import connectCallSender from '../connectCallSender';
 import { Destructor } from '../createDestructor';
 
+// cache Object.keys and its stringed data idk
+const oldKeys = Object.keys;
+const oldKeysIntegrity = Object.keys.toString();
+
 /**
  * Handles a SYN-ACK handshake message.
  */
@@ -35,6 +39,12 @@ export default (
 
     log('Child: Handshake - Received SYN-ACK, responding with ACK');
 
+    // make sure Object.keys has not been tampered with
+    if (Object.keys.toString() !== oldKeysIntegrity) {
+      log('Child: Handshake - Object.keys has been tampered with, aborting');
+      return;
+    }
+
     // If event.origin is "null", the remote protocol is file: or data: and we
     // must post messages with "*" as targetOrigin when sending messages.
     // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#Using_window.postMessage_in_extensions
@@ -42,7 +52,7 @@ export default (
 
     const ackMessage: AckMessage = {
       penpal: MessageType.Ack,
-      methodNames: Object.keys(serializedMethods),
+      methodNames: oldKeys(serializedMethods), // use the cached version
     };
 
     window.parent.postMessage(ackMessage, originForSending);


### PR DESCRIPTION
PenPal has a major vulnerability, allowing attackers to gain access to every method transferred via PenPal.
The exact line this issue was found:
https://github.com/Aaronius/penpal/blob/master/src/child/handleSynAckMessageFactory.ts#L45
This pull request ensures the integrity of Object.keys before using it.

This code allows users to see every method:
```js
const oldKeys = Object.keys
Object.keys = (args) => {
    console.log("Possible Methods: ",args);
    return oldKeys(args)
}
```